### PR TITLE
Allow streaming in download

### DIFF
--- a/synology/filestation.py
+++ b/synology/filestation.py
@@ -228,7 +228,7 @@ class FileStation(Syno):
             }
         ))
 
-    def download(self, path, mode='open'):
+    def download(self, path, mode='open', **kwargs):
         """
         Download files/folders.
         """
@@ -240,7 +240,7 @@ class FileStation(Syno):
                 'path': path,
                 'mode': mode
             }
-        ))
+        ), **kwargs)
 
     def upload(self, path, data, overwrite=True):
         """

--- a/synology/synology.py
+++ b/synology/synology.py
@@ -69,11 +69,14 @@ class Syno():
         r = requests.get(endpoint)
         return self.get_response_data(r)
 
-    def req_binary(self, endpoint):
+    def req_binary(self, endpoint, **kw):
         logging.info('GET: ' + endpoint)
-        r = requests.get(endpoint)
+        r = requests.get(endpoint, **kw)
         if self.is_response_binary(r):
-            return r.content
+            if "stream" in kw:
+              return r
+            else:
+              return r.content
         self.get_response_data(r)
         return None
 


### PR DESCRIPTION
This PR is to allow streaming downloads, e.g.

```python
filest = FileStation('host', 'user', 'pw')

# We can already stream while uploading files
with open("new_file.out") as f:
    jsonprint(filest.upload("/Data/Measurements/new_file.out", f)) 

# We should be able to stream while downloading files
r = filest.download("/Data/Measurements/new_file.out",stream=True) 
with open("temp.out", 'wb') as f:
    for chunk in r.iter_content(chunk_size=1024): 
        if chunk: # filter out keep-alive new chunks
            f.write(chunk)
            f.flush()
```

It also allows passing "extra" keyword parameters to the actual `request` call.  I would suggest this would be good for other API calls, but that should be a separate Pull Request.